### PR TITLE
Add text and audio story support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,21 @@ export default function Demo() {
 }
 ```
 
+### Custom story types
+
+Stories now supports `text` and `audio` story types. You can customize how these
+stories are rendered by passing `renderTextStory` and `renderAudioStory` props.
+
+```jsx
+<Stories
+  data={data}
+  renderTextStory={(story) => <Text>{story.text}</Text>}
+  renderAudioStory={(story) => (
+    <Video source={{ uri: story.url }} audioOnly />
+  )}
+/>
+```
+
 ## About Me
 
 ## Guilherme Luis Faustino

--- a/index.tsx
+++ b/index.tsx
@@ -20,6 +20,8 @@ type Props = {
   avatarStyle?: StyleSheet.Styles;
   titleStyle?: StyleSheet.Styles;
   textReadMore?: string;
+  renderTextStory?: (story: StoryType) => React.ReactNode;
+  renderAudioStory?: (story: StoryType) => React.ReactNode;
 };
 
 const Stories = (props: Props) => {
@@ -125,6 +127,8 @@ const Stories = (props: Props) => {
               dataStories={item}
               isNewStory={index !== currentUserIndex}
               textReadMore={props.textReadMore}
+              renderTextStory={props.renderTextStory}
+              renderAudioStory={props.renderAudioStory}
             />
           ))}
         </CubeNavigationHorizontal>

--- a/src/Story.tsx
+++ b/src/Story.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unused-prop-types */
 import React, {useState} from 'react';
-import {Dimensions, Image, StyleSheet, View} from 'react-native';
+import {Dimensions, Image, StyleSheet, View, Text} from 'react-native';
 import Video from 'react-native-video';
 // import Image from 'react-native-scalable-image';
 import PropTypes from 'prop-types';
@@ -15,6 +15,8 @@ type Props = {
   pause: boolean;
   isLoaded?: boolean;
   isNewStory?: boolean;
+  renderTextStory?: (story: StoryType) => React.ReactNode;
+  renderAudioStory?: (story: StoryType) => React.ReactNode;
 };
 const Story = (props: Props) => {
   const {story} = props;
@@ -35,31 +37,47 @@ const Story = (props: Props) => {
           onLoadEnd={props.onImageLoaded}
           style={styles.content}
           resizeMode="stretch"
-          // width={ScreenWidth}
         />
-      ) : (
+      ) : type === 'video' ? (
         <Video
           source={{uri: url}}
           paused={props.pause || props.isNewStory}
           onLoad={item => {
             const {width, height} = item.naturalSize;
             const heightScaled = height * (ScreenWidth / width);
-            let isPortrait = height > width;
-            setIsPortation(height > width);
+            const isPortrait = height > width;
+            setIsPortation(isPortrait);
             setHeightScaled(heightScaled);
             props.onVideoLoaded(item);
-
-            console.warn(width, height, heightScaled);
-            console.warn('É PAISAGEM?', isPortrait);
           }}
           style={
             isPortation
               ? [styles.contentVideoPortation, {height: heightScaled}]
               : [styles.contentVideo, {height: heightScaled}]
           }
-          resizeMode={'stretch'}
+          resizeMode="stretch"
         />
-      )}
+      ) : type === 'text' ? (
+        props.renderTextStory ? (
+          <>{props.renderTextStory(story)}</>
+        ) : (
+          <View style={styles.textContainer}>
+            <Text style={styles.text}>{story.text || String(url)}</Text>
+          </View>
+        )
+      ) : type === 'audio' ? (
+        props.renderAudioStory ? (
+          <>{props.renderAudioStory(story)}</>
+        ) : (
+          <Video
+            source={{uri: url}}
+            paused={props.pause || props.isNewStory}
+            onLoad={props.onVideoLoaded}
+            audioOnly
+            style={styles.audio}
+          />
+        )
+      ) : null}
     </View>
   );
 };
@@ -97,6 +115,23 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     flex: 1,
+  },
+  textContainer: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  text: {
+    color: 'white',
+    fontSize: 24,
+    textAlign: 'center',
+  },
+  audio: {
+    width: ScreenWidth + 20,
+    height: 50,
+    backgroundColor: '#000',
   },
   loading: {
     backgroundColor: 'black',

--- a/src/StoryContainer.tsx
+++ b/src/StoryContainer.tsx
@@ -26,6 +26,8 @@ type Props = {
   onClose: () => void;
   isNewStory: boolean;
   textReadMore: string;
+  renderTextStory?: (story: StoryType) => React.ReactNode;
+  renderAudioStory?: (story: StoryType) => React.ReactNode;
 };
 
 const StoryContainer: React.FC<Props> = (props: Props) => {
@@ -106,6 +108,8 @@ const StoryContainer: React.FC<Props> = (props: Props) => {
               pause
               onVideoLoaded={onVideoLoaded}
               story={story}
+              renderTextStory={props.renderTextStory}
+              renderAudioStory={props.renderAudioStory}
             />
           </View>
           <ActivityIndicator color="white" />
@@ -155,6 +159,8 @@ const StoryContainer: React.FC<Props> = (props: Props) => {
             isNewStory={props.isNewStory}
             onVideoLoaded={onVideoLoaded}
             story={story}
+            renderTextStory={props.renderTextStory}
+            renderAudioStory={props.renderAudioStory}
           />
 
           {loading()}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,8 @@ export type user = {
 export type StoryType = {
   id?: number;
   url?: string;
-  type?: string | 'image' | 'video' | 'text';
+  text?: string;
+  type?: string | 'image' | 'video' | 'text' | 'audio';
   duration?: number;
   isReadMore?: boolean;
   isSeen?: boolean;


### PR DESCRIPTION
## Summary
- support `text` and `audio` story types
- expose `renderTextStory` and `renderAudioStory` props
- document custom story type support

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d726c47e48323bd02729e6a8692cd